### PR TITLE
Ms 4353 add processing state

### DIFF
--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -15,7 +15,7 @@
   </parent>
 
   <artifactId>promat-connector</artifactId>
-  <version>1.6-SNAPSHOT</version>
+  <version>1.7-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <dependencies>
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>dk.dbc</groupId>
       <artifactId>promat-model</artifactId>
-      <version>1.1-SNAPSHOT</version>
+      <version>1.2-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.microprofile.config</groupId>

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -15,7 +15,7 @@
   </parent>
 
   <artifactId>promat-model</artifactId>
-  <version>1.1-SNAPSHOT</version>
+  <version>1.2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/model/src/main/java/dk/dbc/promat/service/persistence/CaseStatus.java
+++ b/model/src/main/java/dk/dbc/promat/service/persistence/CaseStatus.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Dansk Bibliotekscenter a/s. Licensed under GPLv3
- * See license text in LICENSE.txt or at https://opensource.dbc.dk/licenses/gpl-3.0/
- */
-
 package dk.dbc.promat.service.persistence;
 
 import java.util.Arrays;
@@ -105,6 +100,16 @@ public enum CaseStatus {
     PENDING_EXPORT,
 
     /*
+        Review is being processed by DataIO for export
+
+        Transition from:    PENDING_EXPORT
+        Transition to:      EXPORTED, PENDING_EXPORT
+        Payable:            Yes
+        Visible in DBCKat   Yes
+    */
+    PROCESSING,
+
+    /*
         Review has been exported
 
         Transition from:    PENDING_EXPORT
@@ -119,7 +124,7 @@ public enum CaseStatus {
     /*
         Review has been exported but must be withdrawn and deleted in the datawell
 
-        Transition from:    EXPORTED
+        Transition from:    EXPORTED, PROCESSING
         Transition to:      REVERTED, PENDING_EXPORT
         Payable:            Yes
         Visible in DBCKat   Yes
@@ -129,7 +134,7 @@ public enum CaseStatus {
     /*
         Review has been deleted in the datawell
 
-        Transition from:    PENDING_REVERT
+        Transition from:    PENDING_REVERT, PROCESSING
         Transition to:      PENDING_ISSUES, PENDING_EXPORT (if we allow this)
         Payable:            Yes
         Visible in DBCKat   Yes

--- a/model/src/main/java/dk/dbc/promat/service/persistence/PromatCase.java
+++ b/model/src/main/java/dk/dbc/promat/service/persistence/PromatCase.java
@@ -57,7 +57,10 @@ import java.util.Objects;
                 query = PromatCase.LIST_CASE_BY_FAUST_QUERY),
         @NamedQuery(
                 name = PromatCase.GET_CASES_FOR_REMINDERS_CHECK_NAME,
-                query = PromatCase.GET_CASES_FOR_REMINDERS_CHECK_QUERY)
+                query = PromatCase.GET_CASES_FOR_REMINDERS_CHECK_QUERY),
+        @NamedQuery(
+                name = PromatCase.GET_COUNT_OF_CASES_IN_PROCESSING_STATE_NAME,
+                query = PromatCase.GET_COUNT_OF_CASES_IN_PROCESSING_STATE_QUERY)
 })
 @Entity
 public class PromatCase {
@@ -146,6 +149,11 @@ public class PromatCase {
             "                                                          where c.status in (dk.dbc.promat.service.persistence.CaseStatus.ASSIGNED," +
             "                                                                             dk.dbc.promat.service.persistence.CaseStatus.PENDING_ISSUES)";
 
+    public static final String GET_COUNT_OF_CASES_IN_PROCESSING_STATE_NAME =
+            "PromatCase.get.count.of.cases.in.processing.state";
+    public static final String GET_COUNT_OF_CASES_IN_PROCESSING_STATE_QUERY = "select count(1)" +
+            "                                                  from PromatCase c" +
+            "                                                 where c.status = dk.dbc.promat.service.persistence.CaseStatus.PROCESSING";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -29,13 +29,13 @@
     <dependency>
       <groupId>dk.dbc</groupId>
       <artifactId>promat-connector</artifactId>
-      <version>1.6-SNAPSHOT</version>
+      <version>1.7-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>dk.dbc</groupId>
       <artifactId>promat-model</artifactId>
-      <version>1.1-SNAPSHOT</version>
+      <version>1.2-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.flywaydb</groupId>

--- a/service/src/main/java/dk/dbc/promat/service/api/Cases.java
+++ b/service/src/main/java/dk/dbc/promat/service/api/Cases.java
@@ -1,8 +1,3 @@
-/*
- * Copyright Dansk Bibliotekscenter a/s. Licensed under GPLv3
- * See license text in LICENSE.txt or at https://opensource.dbc.dk/licenses/gpl-3.0/
- */
-
 package dk.dbc.promat.service.api;
 
 import com.fasterxml.jackson.annotation.JsonView;
@@ -1051,18 +1046,18 @@ public class Cases {
                 return CaseStatus.CLOSED;
 
             case EXPORTED:
-                if (existing.getStatus() != CaseStatus.PENDING_EXPORT) {
-                    throw new ServiceErrorException("Not allowed to set status EXPORTED when case is not in PENDING_EXPORT")
-                            .withDetails("Attempt to set status of case to EXPORTED when case is not in status PENDING_EXPORT")
+                if (!existing.in(CaseStatus.PENDING_EXPORT, CaseStatus.PROCESSING)) {
+                    throw new ServiceErrorException("Not allowed to set status EXPORTED when case is not in PENDING_EXPORT or PROCESSING")
+                            .withDetails("Attempt to set status of case to EXPORTED when case is not in status PENDING_EXPORT or PROCESSING")
                             .withHttpStatus(400)
                             .withCode(ServiceErrorCode.INVALID_REQUEST);
                 }
                 return CaseStatus.EXPORTED;
 
             case REVERTED:
-                if (existing.getStatus() != CaseStatus.PENDING_REVERT) {
-                    throw new ServiceErrorException("Not allowed to set status REVERTED when case is not in pending revert")
-                            .withDetails("Attempt to set status of case to REVERTED when case is not in status PENDING_REVERT")
+                if (!existing.in(CaseStatus.PENDING_REVERT, CaseStatus.PROCESSING)) {
+                    throw new ServiceErrorException("Not allowed to set status REVERTED when case is not in PENDING_REVERT or PROCESSING")
+                            .withDetails("Attempt to set status of case to REVERTED when case is not in status PENDING_REVERT or PROCESSING")
                             .withHttpStatus(400)
                             .withCode(ServiceErrorCode.INVALID_REQUEST);
                 }
@@ -1139,9 +1134,9 @@ public class Cases {
                 return CaseStatus.PENDING_ISSUES;
 
             case PENDING_EXPORT:
-                if (!existing.in(CaseStatus.PENDING_MEETING, CaseStatus.APPROVED, CaseStatus.EXPORTED)) {
-                    throw new ServiceErrorException("Not allowed to set status PENDING_EXPORT when case is not in EXPORTED, PENDING_MEETING or APPROVED")
-                            .withDetails("Attempt to set status of case to PENDING_EXPORT when case is not in status EXPORTED, PENDING_MEETING or APPROVED")
+                if (!existing.in(CaseStatus.PENDING_MEETING, CaseStatus.APPROVED, CaseStatus.EXPORTED, CaseStatus.PROCESSING)) {
+                    throw new ServiceErrorException("Not allowed to set status PENDING_EXPORT when case is not in EXPORTED, PENDING_MEETING, APPROVED or PROCESSING")
+                            .withDetails("Attempt to set status of case to PENDING_EXPORT when case is not in status EXPORTED, PENDING_MEETING, APPROVED or PROCESSING")
                             .withHttpStatus(400)
                             .withCode(ServiceErrorCode.INVALID_REQUEST);
                 }
@@ -1157,13 +1152,22 @@ public class Cases {
                 return CaseStatus.PENDING_MEETING;
 
             case PENDING_REVERT:
-                if (existing.getStatus() != CaseStatus.EXPORTED) {
-                    throw new ServiceErrorException("Not allowed to set status PENDING_REVERT when case is not exported")
-                            .withDetails("Attempt to set status of case to PENDING_REVERT when case is not in status EXPORTED")
+                if (!existing.in(CaseStatus.EXPORTED, CaseStatus.PROCESSING)) {
+                    throw new ServiceErrorException("Not allowed to set status PENDING_REVERT when case is not in EXPORTED or PROCESSING")
+                            .withDetails("Attempt to set status of case to PENDING_REVERT when case is not in status EXPORTED or PROCESSING")
                             .withHttpStatus(400)
                             .withCode(ServiceErrorCode.INVALID_REQUEST);
                 }
                 return CaseStatus.PENDING_REVERT;
+
+            case PROCESSING:
+                if (!existing.in(CaseStatus.PENDING_EXPORT, CaseStatus.PENDING_REVERT)) {
+                    throw new ServiceErrorException("Not allowed to set status PROCESSING when case is not in PENDING_EXPORT or PENDING_REVERT")
+                            .withDetails("Attempt to set status of case to PROCESSING when case is not in status PENDING_EXPORT or PENDING_REVERT")
+                            .withHttpStatus(400)
+                            .withCode(ServiceErrorCode.INVALID_REQUEST);
+                }
+                return CaseStatus.PROCESSING;
 
             default:
                 throw new ServiceErrorException("Unknown or forbidden status")

--- a/service/src/main/java/dk/dbc/promat/service/api/ProcessingGauge.java
+++ b/service/src/main/java/dk/dbc/promat/service/api/ProcessingGauge.java
@@ -1,0 +1,56 @@
+package dk.dbc.promat.service.api;
+
+import dk.dbc.promat.service.persistence.PromatCase;
+import dk.dbc.promat.service.persistence.PromatEntityManager;
+import org.eclipse.microprofile.metrics.Gauge;
+import org.eclipse.microprofile.metrics.Metadata;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.MetricType;
+import org.eclipse.microprofile.metrics.annotation.RegistryType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.PostConstruct;
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
+
+@Startup
+@Singleton
+public class ProcessingGauge {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProcessingGauge.class);
+
+    @SuppressWarnings("CdiInjectionPointsInspection")
+    @Inject
+    @RegistryType(type = MetricRegistry.Type.APPLICATION)
+    MetricRegistry metricRegistry;
+
+    @Inject
+    @PromatEntityManager
+    EntityManager entityManager;
+
+    static final Metadata recordHandlerRecordsInProcessingGauge = Metadata.builder()
+            .withName("promat_service_record_handler_records_in_processing")
+            .withDescription("Number of records with status PROCESSING")
+            .withType(MetricType.GAUGE)
+            .withUnit("records")
+            .build();
+
+    Gauge<Long> recordsInProcessingGauge = () -> {
+        TypedQuery<Long> query = entityManager
+                .createNamedQuery(PromatCase.GET_COUNT_OF_CASES_IN_PROCESSING_STATE_NAME, Long.class);
+        return query.getSingleResult();
+    };
+
+    @PostConstruct
+    public void register() {
+        if (metricRegistry != null) {
+            LOGGER.info("Registering {}", recordHandlerRecordsInProcessingGauge.getName());
+            metricRegistry.register(recordHandlerRecordsInProcessingGauge, recordsInProcessingGauge);
+        } else {
+            LOGGER.info("No injected metricRegistry. Unable to register {}", recordHandlerRecordsInProcessingGauge.getName());
+        }
+    }
+}

--- a/service/src/main/java/dk/dbc/promat/service/batch/UserUpdater.java
+++ b/service/src/main/java/dk/dbc/promat/service/batch/UserUpdater.java
@@ -1,49 +1,21 @@
-/*
- * Copyright Dansk Bibliotekscenter a/s. Licensed under GPLv3
- * See license text in LICENSE.txt or at https://opensource.dbc.dk/licenses/gpl-3.0/
- */
-
 package dk.dbc.promat.service.batch;
 
-import dk.dbc.connector.openformat.OpenFormatConnectorException;
-import dk.dbc.promat.service.Repository;
-import dk.dbc.promat.service.api.BibliographicInformation;
-import dk.dbc.promat.service.api.OpenFormatHandler;
 import dk.dbc.promat.service.persistence.Address;
-import dk.dbc.promat.service.persistence.CaseStatus;
 import dk.dbc.promat.service.persistence.Editor;
-import dk.dbc.promat.service.persistence.MaterialType;
-import dk.dbc.promat.service.persistence.PromatCase;
-import dk.dbc.promat.service.persistence.PromatTask;
-import dk.dbc.promat.service.persistence.PromatUser;
 import dk.dbc.promat.service.persistence.Reviewer;
-import dk.dbc.promat.service.persistence.TaskFieldType;
-import dk.dbc.promat.service.util.PromatTaskUtils;
-import org.eclipse.microprofile.metrics.ConcurrentGauge;
 import org.eclipse.microprofile.metrics.Metadata;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.MetricType;
-import org.eclipse.microprofile.metrics.MetricUnits;
 import org.eclipse.microprofile.metrics.annotation.RegistryType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ejb.EJB;
 import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
 import javax.inject.Inject;
-import java.time.Duration;
-import java.time.LocalDate;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.Arrays;
-import java.util.Comparator;
 import java.util.Date;
-import java.util.List;
-import java.util.Locale;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Stateless
 public class UserUpdater {

--- a/service/src/test/java/dk/dbc/promat/service/api/PaymentsIT.java
+++ b/service/src/test/java/dk/dbc/promat/service/api/PaymentsIT.java
@@ -1,8 +1,3 @@
- /*
- * Copyright Dansk Bibliotekscenter a/s. Licensed under GPLv3
- * See license text in LICENSE.txt or at https://opensource.dbc.dk/licenses/gpl-3.0/
- */
-
 package dk.dbc.promat.service.api;
 
  import com.fasterxml.jackson.core.JsonProcessingException;
@@ -100,7 +95,7 @@ public class PaymentsIT  extends ContainerTest {
         assertThat("status code", response.getStatus(), is(200));
 
         String csv = response.readEntity(String.class);
-        assertThat("number of lines", csv.lines().count(), is(35L));  // 1 header + 34 paymentlines
+        assertThat("number of lines", csv.lines().count(), is(36L));  // 1 header + 34 paymentlines
     }
 
     // This test needs to run after test that depends on the state of the preloaded cases
@@ -111,7 +106,7 @@ public class PaymentsIT  extends ContainerTest {
         assertThat("status code", response.getStatus(), is(200));
 
         PaymentList payments = mapper.readValue(response.readEntity(String.class), PaymentList.class);
-        assertThat("number of paymentlines", payments.getPayments().size(), is(34));
+        assertThat("number of paymentlines", payments.getPayments().size(), is(35));
     }
 
     // This test needs to run after test that depends on the state of the preloaded cases
@@ -122,7 +117,7 @@ public class PaymentsIT  extends ContainerTest {
         assertThat("status code", response.getStatus(), is(200));
 
         String csv = response.readEntity(String.class);
-        assertThat("number of lines", csv.lines().count(), is(35L));  // 1 header + 34 paymentlines
+        assertThat("number of lines", csv.lines().count(), is(36L));  // 1 header + 35 paymentlines
 
         verifyPaymentCsv(csv);
     }
@@ -137,7 +132,7 @@ public class PaymentsIT  extends ContainerTest {
         assertThat("status code", response.getStatus(), is(200));
 
         String csv = response.readEntity(String.class);
-        assertThat("number of lines", csv.lines().count(), is(35L));  // 1 header + 34 paymentlines
+        assertThat("number of lines", csv.lines().count(), is(36L));  // 1 header + 34 paymentlines
 
         // Now check that all pending payments has been payed
         response = getResponse("v1/api/payments/preview", Map.of("format","CSV"));
@@ -176,7 +171,7 @@ public class PaymentsIT  extends ContainerTest {
         assertThat("status code", response.getStatus(), is(200));
 
         String csv = response.readEntity(String.class);
-        assertThat("number of lines", csv.lines().count(), is(35L));  // 1 header + 34 paymentlines
+        assertThat("number of lines", csv.lines().count(), is(36L));  // 1 header + 35 paymentlines
 
         verifyPaymentCsv(csv);
     }
@@ -191,6 +186,7 @@ public class PaymentsIT  extends ContainerTest {
                 "mm-dd-åååå;123;1956;1;100007 Title for 100007;Hans Hansen\n" +
                 "mm-dd-åååå;123;1956;1;100008 Title for 100008;Hans Hansen\n" +
                 "mm-dd-åååå;123;1956;1;100009 Title for 100009;Hans Hansen\n" +
+                "mm-dd-åååå;123;1956;1;319997 Title for 319997;Hans Hansen\n" +
                 "mm-dd-åååå;123;1956;1;1001000 Case 1;Hans Hansen\n" +
                 "mm-dd-åååå;123;1956;1;1001010 Case 2;Hans Hansen\n" +
                 "mm-dd-åååå;123;1956;1;1001020 Case 3;Hans Hansen\n" +

--- a/service/src/test/resources/dk/dbc/promat/service/db/promatcases.sql
+++ b/service/src/test/resources/dk/dbc/promat/service/db/promatcases.sql
@@ -49,7 +49,8 @@ values (1, 'Title for 001111', 'Details for 001111', '001111',    '[]', NULL, NU
        (24, 'Title for 100006', 'Details for 100006', '100006',   '[]', 1,    10,   '2021-01-09', '2021-02-09', '2021-01-10', 'ASSIGNED',         'BOOK',  'BKM202104', '202104', 13, 'Author for 100000', 'Publisher for 100006', '["BKX202107"]'),
        (25, 'Title for 100007', 'Details for 100007', '100007',   '[]', 1,    10,   '2021-01-27', '2021-02-27', '2021-01-27', 'PENDING_EXPORT',   'BOOK',  null,        null,     13, '',                  '', '[]'),
        (26, 'Title for 100008', 'Details for 100008', '100008',   '[]', 1,    10,   '2021-01-27', '2021-02-27', '2021-01-27', 'PENDING_EXPORT',   'BOOK',  null,        null,     13, '',                  '', '[]'),
-       (27, 'Title for 100009', 'Details for 100009', '100009',   '[]', 1,    10, '  2021-01-27', '2021-02-27', '2021-01-27', 'PENDING_EXPORT',   'BOOK',  null,        null,     13, '',                  '', '[]');
+       (27, 'Title for 100009', 'Details for 100009', '100009',   '[]', 1,    10, '  2021-01-27', '2021-02-27', '2021-01-27', 'PENDING_EXPORT',   'BOOK',  null,        null,     13, '',                  '', '[]'),
+       (28, 'Title for 319997', 'Details for 319997', '319997',   '[]', 1,    10,   '2021-01-27', '2021-02-27', '2021-01-27', 'PENDING_EXPORT',   'BOOK',  null,        null,     13, '',                  '', '[]');
 
 insert into promattask(id, tasktype, taskfieldtype, created, paycategory, approved, payed, data, targetFausts)
 values  (1,  'GROUP_1_LESS_THAN_100_PAGES', 'DESCRIPTION',    '202-12-10', 'GROUP_1_LESS_THAN_100_PAGES', '2020-12-10',  NULL,         NULL,                           '["001111", "002222", "003333"]'),
@@ -110,7 +111,8 @@ insert into promattask(id, tasktype, taskfieldtype, created, paycategory, approv
 values  (49, 'GROUP_1_LESS_THAN_100_PAGES', 'BRIEF',          '2021-01-27', 'BRIEF',                       '2021-02-08', NULL, 'Ready to export, no faust', '["019997"]', NULL),
         (50, 'GROUP_1_LESS_THAN_100_PAGES', 'BRIEF',          '2021-01-27', 'BRIEF',                       '2021-02-08', NULL, 'Ready to export, with faust', '["100007"]', '123456789'),
         (51, 'GROUP_1_LESS_THAN_100_PAGES', 'DESCRIPTION',    '2021-01-27', 'GROUP_1_LESS_THAN_100_PAGES', '2021-02-08', NULL, 'Ready to export, no faust, not BRIEF', '["100008"]', NULL),
-        (52, 'GROUP_1_LESS_THAN_100_PAGES', 'DESCRIPTION',    '2021-01-27', 'GROUP_1_LESS_THAN_100_PAGES', '2021-02-08', NULL, 'Ready to export, with faust, not BRIEF', '["100009"]', '987654321');
+        (52, 'GROUP_1_LESS_THAN_100_PAGES', 'DESCRIPTION',    '2021-01-27', 'GROUP_1_LESS_THAN_100_PAGES', '2021-02-08', NULL, 'Ready to export, with faust, not BRIEF', '["100009"]', '987654321'),
+        (58, 'GROUP_1_LESS_THAN_100_PAGES', 'BRIEF',          '2021-01-27', 'BRIEF',                       '2021-02-08', NULL, 'Ready to export, no faust', '["319997"]', NULL);
 
 insert into casetasks(case_id, task_id)
 values (1, 1),
@@ -169,4 +171,5 @@ values (1, 1),
        (2, 54),
        (2, 55),
        (2, 56),
-       (2, 57);
+       (2, 57),
+       (28, 58);


### PR DESCRIPTION
To allow us to move records under export into a temporary state. Preventing multiple exports of the same records should
any errors occur in either promat-service or dataio