### PR TITLE
Move status on a case back to PENDING_EXTERNAL

### DIFF
--- a/service/src/main/java/dk/dbc/promat/service/api/Cases.java
+++ b/service/src/main/java/dk/dbc/promat/service/api/Cases.java
@@ -779,6 +779,12 @@ public class Cases {
             // Add the new task
             promatCase.getTasks().add(task);
 
+            // Reset potential approved case in special cases METAKOMPAS and BUGGI.
+            if (List.of(TaskFieldType.METAKOMPAS, TaskFieldType.BUGGI).contains(task.getTaskFieldType()) &&
+                    promatCase.getStatus() == CaseStatus.APPROVED) {
+                promatCase.setStatus(CaseStatus.PENDING_EXTERNAL);
+            }
+
             return Response.status(201)
                     .entity(task)
                     .build();


### PR DESCRIPTION
when new BUGGI/METAKOMPAS task is added to an already APPROVED case.