### PR TITLE
Extend text in mail message regarding printed version of the book

### DIFF
--- a/service/src/main/resources/jte/templates/tag/how_to_get_material_tag.jte
+++ b/service/src/main/resources/jte/templates/tag/how_to_get_material_tag.jte
@@ -18,7 +18,7 @@
 @endif
 
 @if (material.equals("Printfile"))
-    Link til åbning af fil findes i promat.
+    Link til åbning af fil findes i promat, og den trykte bog er på vej i posten.
 @elseif (material.equals("Ebog"))
     Link til åbning af Ebog findes i promat.
 @else

--- a/service/src/test/resources/mailBodys/printfileReview.html
+++ b/service/src/test/resources/mailBodys/printfileReview.html
@@ -50,7 +50,7 @@
 
 
 
-Link til åbning af fil findes i promat.
+Link til åbning af fil findes i promat, og den trykte bog er på vej i posten.
 
 
 


### PR DESCRIPTION
It seems that if type 'Printfile' has been determined, there should be a printed book, and in that case, it should be slowmailed to the reviewer

If type 'Book' og 'EBook' has been determined, we must assume that only the electronic version exists, and thus no book is in slowmail